### PR TITLE
Define all gateway workspaces by default. Change README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
-you need a running docker to do the s3 tests
+# Testing
 
-on mac colima is a good choice
+All connectors are enabled by default in the Fireproof test suite. To run a test for a single connector, you can use the Vitest workspace configuration. 
+
+For example, to run tests for the PartyKit connector only, you can use the following command:
+
+```console
+$ npm test -- --project partykit
+```

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,10 +1,10 @@
 import { defineWorkspace } from "vitest/config";
 
+import aws from "./vitest.aws.config.ts";
 import betterSqlite3 from "./vitest.better-sqlite3.config.ts";
 import nodeSqlite3Wasm from "./vitest.node-sqlite3-wasm.config.ts";
-import s3 from "./vitest.s3.config.ts";
 import partykit from "./vitest.partykit.config.ts";
-import aws from "./vitest.aws.config.ts";
+import s3 from "./vitest.s3.config.ts";
 // import connector from "./vitest.connector.config.ts";
 import netlify from "./vitest.netlify.config.ts";
 // import cf_kv from "./vitest.cf-kv.config.ts";
@@ -20,9 +20,9 @@ export default defineWorkspace([
   nodeSqlite3Wasm,
   betterSqlite3,
   // connector,
-  // s3,
-  // aws,
-  // netlify,
-  // partykit,
+  s3,
+  aws,
+  netlify,
+  partykit,
   //cf_kv
 ]);


### PR DESCRIPTION
vitest provides an option to run a single project (a gateway in our case). this enables all gateways for testing, and adds a note how to run a single one. I think it is better than constantly changing the workspace.ts.

to run a single connector test, use  
```
npm test -- --project partykit