### PR TITLE
switch CI to use fireproof main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: v0.19.9-dev-frag
           repository: fireproof-storage/fireproof
           path: ./fireproof
       - name: build-fireproof-package


### PR DESCRIPTION
I cherry-picked this from another branch, as I believe this should get fixed ASAP.

This changes the build to pull fireproof main (not another tag/branch), and install that for dependency purposes.

I feel we're working directly on main with fireproof now, and all the major breaking changes have landed.