### PR TITLE
fix installing @fireproof/core with tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           git config --global url."https://".insteadOf git+ssh://
           git config --global -l
-          ls -l ../fireproof/dist/fireproof-core/
+          pnpm remove @fireproof/core
           pnpm install -f ../fireproof/dist/fireproof-core/fireproof-core-*.tgz
           pnpm install
 


### PR DESCRIPTION
with the tag set, the tgz gets a different name
the install command tries to use * to find it
which works, but the wrong name is still the packag.json this removes the old dep first, then force installs the correct one