### PR TITLE
Limit the polling interval.

### DIFF
--- a/src/aws/gateway.ts
+++ b/src/aws/gateway.ts
@@ -265,7 +265,7 @@ export class AWSGateway implements bs.Gateway {
           callback(data);
           interval = 100; // Reset interval when data changes
         } else {
-          interval *= 2; // Double the interval when data is unchanged
+          interval = Math.min(interval * 2, 3000); // Double the interval when data is unchanged, but limit to 3 secs
         }
       }
       timeoutId = setTimeout(fetchData, interval);

--- a/src/netlify/gateway.ts
+++ b/src/netlify/gateway.ts
@@ -202,7 +202,7 @@ export class NetlifyGateway implements bs.Gateway {
           callback(data);
           interval = 100; // Reset interval when data changes
         } else {
-          interval *= 2; // Double the interval when data is unchanged
+          interval = Math.min(interval * 2, 3000);
         }
       }
       timeoutId = setTimeout(fetchData, interval);


### PR DESCRIPTION
Limits the polling interval for latest data to 3 secs.
Imagine being in read-mode (eg reading chat messages in a chat channel) and not getting any data for a long time when the page is idle.