### PR TITLE
include index.global.js in npm packages

### DIFF
--- a/package-aws.json
+++ b/package-aws.json
@@ -4,10 +4,12 @@
   "description": "PartyKit gateway for AWS",
   "main": "./index.cjs",
   "module": "./index.js",
+  "browser": "./index.global.js",
   "exports": {
     ".": {
       "import": "./index.js",
       "require": "./index.cjs",
+      "script": "./index.global.js",
       "types": "./index.d.ts"
     }
   },

--- a/package-netlify.json
+++ b/package-netlify.json
@@ -4,10 +4,12 @@
   "description": "PartyKit gateway for Netlify",
   "main": "./index.cjs",
   "module": "./index.js",
+  "browser": "./index.global.js",
   "exports": {
     ".": {
       "import": "./index.js",
       "require": "./index.cjs",
+      "script": "./index.global.js",
       "types": "./index.d.ts"
     }
   },

--- a/package-partykit.json
+++ b/package-partykit.json
@@ -4,10 +4,12 @@
   "description": "PartyKit gateway for Fireproof",
   "main": "./index.cjs",
   "module": "./index.js",
+  "browser": "./index.global.js",
   "exports": {
     ".": {
       "import": "./index.js",
       "require": "./index.cjs",
+      "script": "./index.global.js",
       "types": "./index.d.ts"
     }
   },


### PR DESCRIPTION
this should fix partykit, netlify and aws
s3 is still broken as there is no global js generated yet