### PR TITLE
fix 500 observed in netlify logs

### DIFF
--- a/src/netlify/server.ts
+++ b/src/netlify/server.ts
@@ -39,9 +39,13 @@ export default async (req: Request) => {
       const entries = (
         await Promise.all(
           blobs.map(async (blob) => {
-            const { data, parents } = await meta.get(blob.key, {
+            const blobContents = await meta.get(blob.key, {
               type: "json",
             });
+            if (!blobContents) {
+              return { data: null };
+            }
+            const { data, parents } = blobContents;
             if (parents) {
               for (const p of parents) {
                 allParents.push(p.toString());

--- a/src/netlify/server.ts
+++ b/src/netlify/server.ts
@@ -43,7 +43,7 @@ export default async (req: Request) => {
               type: "json",
             });
             if (!blobContents) {
-              return { data: null };
+              return { cid: blob.key.split("/")[1], data: null };
             }
             const { data, parents } = blobContents;
             if (parents) {

--- a/tests/connect-netlify/app/netlify/edge-functions/fireproof.ts
+++ b/tests/connect-netlify/app/netlify/edge-functions/fireproof.ts
@@ -39,9 +39,13 @@ export default async (req: Request) => {
       const entries = (
         await Promise.all(
           blobs.map(async (blob) => {
-            const { data, parents } = await meta.get(blob.key, {
+            const blobContents = await meta.get(blob.key, {
               type: "json",
             });
+            if (!blobContents) {
+              return { data: null };
+            }
+            const { data, parents } = blobContents;
             if (parents) {
               for (const p of parents) {
                 allParents.push(p.toString());

--- a/tests/connect-netlify/app/netlify/edge-functions/fireproof.ts
+++ b/tests/connect-netlify/app/netlify/edge-functions/fireproof.ts
@@ -43,7 +43,7 @@ export default async (req: Request) => {
               type: "json",
             });
             if (!blobContents) {
-              return { data: null };
+              return { cid: blob.key.split("/")[1], data: null };
             }
             const { data, parents } = blobContents;
             if (parents) {


### PR DESCRIPTION
this was fixed in the netlfy integration but not properly moved upstream

```
Oct 3, 02:37:06 PM: 01J9A51B info   request  GET https://fireproof-gateway-demo.netlify.app/fireproof?meta=fptest2.fp
Oct 3, 02:37:06 PM: 01J9A51B info   TypeError: Cannot destructure property 'data' of '(intermediate value)' as it is null.
Oct 3, 02:37:06 PM: 01J9A51B info       at file:///root/netlify/edge-functions/fireproof.ts:45:33
Oct 3, 02:37:06 PM: 01J9A51B info       at eventLoopTick (ext:core/01_core.js:168:7)
Oct 3, 02:37:06 PM: 01J9A51B info       at async Promise.all (index 0)
Oct 3, 02:37:06 PM: 01J9A51B info       at async default (file:///root/netlify/edge-functions/fireproof.ts:43:17)
Oct 3, 02:37:06 PM: 01J9A51B info       at async FunctionChain.runFunction (file:///root/src/bootstrap/function_chain.ts:420:22)
Oct 3, 02:37:06 PM: 01J9A51B info       at async FunctionChain.run (file:///root/src/bootstrap/function_chain.ts:324:20)
Oct 3, 02:37:06 PM: 01J9A51B info       at async handleRequest (file:///root/src/bootstrap/handler.ts:148:22)
Oct 3, 02:37:06 PM: 01J9A51B info       at async ext:deno_http/00_serve.ts:364:18
```