### PR TITLE
Change sync db name for convention

### DIFF
--- a/src/cloud/index.ts
+++ b/src/cloud/index.ts
@@ -9,7 +9,7 @@ interface ConnectData {
   endpoint?: string;
 }
 
-const SYNC_DB_NAME = "_fp.sync";
+const SYNC_DB_NAME = "fp_sync";
 
 // Usage:
 //


### PR DESCRIPTION
Internally,  IndexedDb names are sanitized so this ends up being fp.fp.sync . Use fp_ prefix for meta dbs ala sqlite (sqlite_), postgresql (pg_)